### PR TITLE
Generate a man page for light on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,31 @@
 PREFIX=$(DESTDIR)/usr
 BINDIR=$(PREFIX)/bin
+MANDIR=/usr/share/man/man1
 
 CC=gcc
 CFLAGS=-std=c89 -O2 -pedantic -Wall -I"./include"
+MANFLAGS=-h -h -v -V
 
 all:
 	$(CC) $(CFLAGS) -g -o light src/helpers.c src/light.c src/main.c
 exp:
 	$(CC) $(CFLAGS) -E  src/helpers.c src/light.c
+man:
+	help2man $(MANFLAGS) ./light | gzip - > light.1.gz
 
-install: all
+install: all man
 	mkdir -p $(BINDIR)
 	cp -f ./light $(BINDIR)/light
 	chown root $(BINDIR)/light
 	chmod 4755 $(BINDIR)/light
+	mkdir -p $(MANDIR)
+	mv light.1.gz $(MANDIR)
 
 uninstall:
 	rm $(BINDIR)/light
 	rm -rf /etc/light
+	rm $(MANDIR)/light.1.gz
 
 clean:
-	rm -vfr *~ light
+	rm -vfr *~ light light.1.gz
 	


### PR DESCRIPTION
A man page is generated using help2man when make install is executed.
help2man uses the `light -V`and `light -h` commands to generate a man page from the texts printed there. After generation, the man page is copied to the man pages directory.
Clean and install remove the man pages from the system.

The man directory and the flags for help2man can easily be adapted in the respective variables.