### PR TITLE
Honor DESTDIR in man page installation.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PREFIX=$(DESTDIR)/usr
 BINDIR=$(PREFIX)/bin
-MANDIR=/usr/share/man/man1
+MANDIR=$(PREFIX)/share/man/man1
 
 CC=gcc
 CFLAGS=-std=c89 -O2 -pedantic -Wall -I"./include"


### PR DESCRIPTION
Commit 2fcbd32 introduces `MANDIR` for installing the man page, which breaks installation in a local environment (e.g. for makepkg build on Arch). This change should fix that.