### PR TITLE
Add -k flag for keyboard backlight support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ As you can not only handle the **brightness** of controllers, you may also speci
 * -b: Current brightness of selected controller
 * -m: Maximum brightness of selected controller
 * -c: Minimum brightness (cap) of selected controller
+* -k: Set keyboard brightness instead of display brightness
 
 The minimum brightness is a feature implemented as some controllers make the screen go pitch black at 0%, if you have a controller like that, it is recommended to set this value (in either percent or in raw mode). These values will be saved in raw mode though, so if you specify it in percent it might not be too accurate depending on your controller.
 

--- a/include/light.h
+++ b/include/light.h
@@ -49,7 +49,9 @@ typedef enum LIGHT_TARGET {
   LIGHT_BRIGHTNESS = 0,
   LIGHT_MAX_BRIGHTNESS,
   LIGHT_MIN_CAP,
-  LIGHT_SAVERESTORE
+  LIGHT_SAVERESTORE,
+  LIGHT_KEYBOARD,
+  LIGHT_KEYBOARD_MAX_BRIGHTNESS
 } LIGHT_TARGET;
 
 typedef enum LIGHT_CTRL_MODE {
@@ -85,7 +87,7 @@ typedef struct light_runtimeArguments_s {
   LIGHT_VAL_MODE  valueMode;
   unsigned long   specifiedValueRaw; /* The specified value in raw mode */
   double          specifiedValuePercent; /* The specified value in percent */
-  
+
   LIGHT_TARGET    target;
 } light_runtimeArguments, *light_runtimeArguments_p;
 


### PR DESCRIPTION
This finally addresses #13 . Keyboard brightness can now be increased like this:
`light -k -A 5` etc.
Tested on Macbook Pro with Fedora 25.