### PR TITLE
Fix save and restore arguments

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -37,7 +37,8 @@ LIGHT_BOOL light_checkOperations()
   switch (light_Configuration.field) {
   case LIGHT_BRIGHTNESS:
     if(op != LIGHT_GET && op != LIGHT_SET &&
-       op != LIGHT_ADD && op != LIGHT_SUB)
+       op != LIGHT_ADD && op != LIGHT_SUB && 
+       op != LIGHT_SAVE && op != LIGHT_RESTORE)
     {
       valid = FALSE;
       fprintf(stderr, "Wrong operation specified for brightness. You can use only -G -S -A or -U\n\n");


### PR DESCRIPTION
Without this patch -O and -I are not supported anymore and lead to an error.