### PR TITLE
Better Support for Overriding Install Prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-PREFIX=$(DESTDIR)/usr
+ifeq ($(PREFIX),)
+	PREFIX := /usr
+endif
 BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man/man1
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ifeq ($(PREFIX),)
 	PREFIX := /usr
 endif
-BINDIR=$(PREFIX)/bin
-MANDIR=$(PREFIX)/share/man/man1
+BINDIR=$(DESTDIR)$(PREFIX)/bin
+MANDIR=$(DESTDIR)$(PREFIX)/share/man/man1
 
 CC=gcc
 CFLAGS=-std=c89 -O2 -pedantic -Wall -I"./include" -D_XOPEN_SOURCE=500


### PR DESCRIPTION
By not always appending "/usr" to the path, it enables install into /usr/local
and better integration with tools like stow.