### PR TITLE
Respect XDG_CACHE_HOME

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -303,10 +303,15 @@ bool light_initialize(int argc, char **argv)
 	int rc;
 
 	/* Classic SUID root mode or new user based cache files */
-	if (geteuid() == 0)
+	if (geteuid() == 0) {
 		snprintf(ctx.prefix, sizeof(ctx.prefix), "%s", "/etc/light");
-	else
-		snprintf(ctx.prefix, sizeof(ctx.prefix), "%s/.cache/light", getenv("HOME"));
+	} else {
+		char *xdg_cache = getenv("XDG_CACHE_HOME");
+		if (xdg_cache != NULL)
+			snprintf(ctx.prefix, sizeof(ctx.prefix), "%s/light", xdg_cache);
+		else
+			snprintf(ctx.prefix, sizeof(ctx.prefix), "%s/.cache/light", getenv("HOME"));
+	}
 
 	light_defaults();
 	if (!light_parse_args(argc, argv)) {


### PR DESCRIPTION
The XDG Base Directory specification [1] demands that there should be a
"single base directory relative to which user-specific non-essential
(cached) data should be written". Light currently makes use of such a
cache directory, but hardcodes the default "$HOME/.cache".

In order to enable users to specify a custom cache directory, respect
this convention and use the "$XDG_CACHE_HOME" environment variable if it
is set. If it is not set, fall back to "$HOME/.cache".

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html