### PR TITLE
debian: install udev rules under /lib

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,8 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 	dh $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- --with-udev
+	dh_auto_configure -- --with-udev=/lib/udev/rules.d
+
 
 override_dh_installchangelogs:
 	dh_installchangelogs ChangeLog.md


### PR DESCRIPTION
Fixes #75.