### PR TITLE
Fix github light release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ and you're good to go.
 ### Debian/Ubuntu
 
 Pre-built .deb files, for the latest Ubuntu release, can be downloaded
-from the [GitHub][Light] releases page.  If you want to build your own
+from the [GitHub](https://github.com/haikarainen/light/releases/) releases page.  If you want to build your own
 there is native support available in the GIT sources.  Clone and follow
 the development branch guidelines below followed by:
 


### PR DESCRIPTION
The github releases page was wrong. This will help users to install light faster.