### PR TITLE
Improve coding style - consistency of not placing a whitespace after `if`, and `while`

### DIFF
--- a/src/helpers.c
+++ b/src/helpers.c
@@ -16,13 +16,13 @@ bool light_file_read_uint64(char const *filename, uint64_t *val)
     uint64_t data;
 
     fp = fopen(filename, "r");
-    if (!fp)
+    if(!fp)
     {
         LIGHT_PERMERR("reading");
         return false;
     }
 
-    if (fscanf(fp, "%lu", &data) != 1)
+    if(fscanf(fp, "%lu", &data) != 1)
     {
         LIGHT_ERR("Couldn't parse an unsigned integer from '%s'", filename);
         fclose(fp);
@@ -40,13 +40,13 @@ bool light_file_write_uint64(char const *filename, uint64_t val)
     FILE *fp;
 
     fp = fopen(filename, "w");
-    if (!fp)
+    if(!fp)
     {
         LIGHT_PERMERR("writing");
         return false;
     }
 
-    if (fprintf(fp, "%lu", val) < 0)
+    if(fprintf(fp, "%lu", val) < 0)
     {
         LIGHT_ERR("fprintf failed");
         fclose(fp);
@@ -68,7 +68,7 @@ bool light_file_is_writable(char const *filename)
     FILE *fp;
 
     fp = fopen(filename, "r+");
-    if (!fp)
+    if(!fp)
     {
         LIGHT_PERMWARN("writing");
         return false;
@@ -84,7 +84,7 @@ bool light_file_is_readable(char const *filename)
     FILE *fp;
 
     fp = fopen(filename, "r");
-    if (!fp)
+    if(!fp)
     {
         LIGHT_PERMWARN("reading");
         return false;
@@ -111,13 +111,13 @@ uint64_t light_log_clamp_max(uint64_t max)
 /* Clamps the `percent` value between 0% and 100% */
 double light_percent_clamp(double val)
 {
-    if (val < 0.0)
+    if(val < 0.0)
     {
         LIGHT_WARN("specified value %g%% is not valid, adjusting it to 0%%", val);
         return 0.0;
     }
 
-    if (val > 100.0)
+    if(val > 100.0)
     {
         LIGHT_WARN("specified value %g%% is not valid, adjusting it to 100%%", val);
         return 100.0;
@@ -130,13 +130,13 @@ int light_mkpath(char *dir, mode_t mode)
 {
     struct stat sb;
 
-    if (!dir)
+    if(!dir)
     {
         errno = EINVAL;
         return -1;
     }
 
-    if (!stat(dir, &sb))
+    if(!stat(dir, &sb))
         return 0;
 
     char *tempdir = strdup(dir);

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -24,7 +24,7 @@ typedef enum {
 light_loglevel_t light_loglevel;
 
 #define LIGHT_LOG(lvl, fp, fmt, args...)\
-    if (light_loglevel >= lvl)\
+    if(light_loglevel >= lvl)\
         fprintf(fp, "%s:%d:" fmt "\n", __FILE__, __LINE__, ##args)
 
 #define LIGHT_NOTE(fmt, args...) LIGHT_LOG(LIGHT_NOTE_LEVEL,  stdout, " Notice: " fmt, ##args)

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -35,7 +35,7 @@ light_loglevel_t light_loglevel;
     do {\
         log("could not open '%s' for " act, filename);\
         log("Verify it exists with the right permissions");\
-    } while (0)
+    } while(0)
 
 #define LIGHT_PERMERR(x)         LIGHT_PERMLOG(x, LIGHT_ERR)
 #define LIGHT_PERMWARN(x)        LIGHT_PERMLOG(x, LIGHT_WARN)

--- a/src/light.c
+++ b/src/light.c
@@ -248,14 +248,14 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
             // Options
             
             case 'v':
-                if (sscanf(optarg, "%i", &log_level) != 1)
+                if(sscanf(optarg, "%i", &log_level) != 1)
                 {
                     fprintf(stderr, "-v argument is not an integer.\n\n");
                     _light_print_usage();
                     return false;
                 }
                 
-                if (log_level < 0 || log_level > 3)
+                if(log_level < 0 || log_level > 3)
                 {
                     fprintf(stderr, "-v argument must be between 0 and 3.\n\n");
                     _light_print_usage();
@@ -358,7 +358,7 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
 
     if(need_value || need_float_value)
     {
-        if ( (argc - optind) != 1)
+        if( (argc - optind) != 1)
         {
             fprintf(stderr, "please specify a <value> for this command.\n\n");
             _light_print_usage();
@@ -366,11 +366,11 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
         }
     }
 
-    if (need_value)
+    if(need_value)
     {
-        if (ctx->run_params.raw_mode)
+        if(ctx->run_params.raw_mode)
         {
-            if (sscanf(argv[optind], "%lu", &ctx->run_params.value) != 1)
+            if(sscanf(argv[optind], "%lu", &ctx->run_params.value) != 1)
             {
                 fprintf(stderr, "<value> is not an integer.\n\n");
                 _light_print_usage();
@@ -380,7 +380,7 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
         else
         {
             double percent_value = 0.0;
-            if (sscanf(argv[optind], "%lf", &percent_value) != 1)
+            if(sscanf(argv[optind], "%lf", &percent_value) != 1)
             {
                 fprintf(stderr, "<value> is not a decimal.\n\n");
                 _light_print_usage();
@@ -400,9 +400,9 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
         }
     }
 
-    if (need_float_value)
+    if(need_float_value)
     {
-        if (sscanf(argv[optind], "%f", &ctx->run_params.float_value) != 1)
+        if(sscanf(argv[optind], "%f", &ctx->run_params.float_value) != 1)
         {
             fprintf(stderr, "<value> is not a float.\n\n");
             _light_print_usage();
@@ -433,7 +433,7 @@ light_context_t* light_initialize(int argc, char **argv)
 
     // Setup the configuration folder
     // If we are root, use the system-wide configuration folder, otherwise try to find a user-specific folder, or fall back to ~/.config
-    if (geteuid() == 0)
+    if(geteuid() == 0)
     {
         snprintf(new_ctx->sys_params.conf_dir, sizeof(new_ctx->sys_params.conf_dir), "%s", "/etc/light");
     }
@@ -441,7 +441,7 @@ light_context_t* light_initialize(int argc, char **argv)
     {
         char *xdg_conf = getenv("XDG_CONFIG_HOME");
         
-        if (xdg_conf != NULL)
+        if(xdg_conf != NULL)
         {
             snprintf(new_ctx->sys_params.conf_dir, sizeof(new_ctx->sys_params.conf_dir), "%s/light", xdg_conf);
         }
@@ -453,7 +453,7 @@ light_context_t* light_initialize(int argc, char **argv)
     
     // Make sure the configuration folder exists, otherwise attempt to create it
     int32_t rc = light_mkpath(new_ctx->sys_params.conf_dir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-    if (rc && errno != EEXIST)
+    if(rc && errno != EEXIST)
     {
         LIGHT_WARN("couldn't create configuration directory");
         return false;
@@ -789,7 +789,7 @@ bool light_cmd_set_min_brightness(light_context_t *ctx)
     
     // Make sure the target folder exists, otherwise attempt to create it
     int32_t rc = light_mkpath(target_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-    if (rc && errno != EEXIST)
+    if(rc && errno != EEXIST)
     {
         LIGHT_ERR("couldn't create target directory for minimum brightness");
         return false;
@@ -994,7 +994,7 @@ bool light_cmd_save_brightness(light_context_t *ctx)
     
     // Make sure the target folder exists, otherwise attempt to create it
     int32_t rc = light_mkpath(target_path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-    if (rc && errno != EEXIST)
+    if(rc && errno != EEXIST)
     {
         LIGHT_ERR("couldn't create target directory for save brightness");
         return false;

--- a/src/main.c
+++ b/src/main.c
@@ -11,12 +11,12 @@
 int main(int argc, char **argv)
 {
     light_context_t *light_ctx = light_initialize(argc, argv);
-    if (light_ctx == NULL) {
+    if(light_ctx == NULL) {
         LIGHT_ERR("Initialization failed");
         return LIGHT_RETURNVAL_INITFAIL;
     }
 
-    if (!light_execute(light_ctx)) {
+    if(!light_execute(light_ctx)) {
         LIGHT_ERR("Execution failed");
         light_free(light_ctx);
         return LIGHT_RETURNVAL_EXECFAIL;


### PR DESCRIPTION
This commit contains coding style improvements only.

Since most `if` and `while` are **not followed by a whitespace**, I removed each single whitespace following these keywords. Hopefully this improves consistency and readability. Thanks.