### PR TITLE
Update Ubuntu section with video group instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ the development branch guidelines below followed by:
 
     make deb
 
+**Note:** you must be in the `video` group. Add yourself to it by running `sudo usermod -a -G video $USER`.
+
 ### <a name="nix"></a>NixOS/nix
 
 You can add the following line to your `configuration.nix`:


### PR DESCRIPTION
I'm one of those that got tripped up when installing on Ubuntu, because I had missed to add my user to the `video` group. This PR adds a brief note to the README to help with that.

You might want to add more comments, or restructure the contents, to clarify further. But it felt more productive to give you a PR rather than just another comment in the issue. Feel free to reject this if you don't think this was worth while, or add more to it or whatever.

Resolves #100