### PR TITLE
Add light_context_mode enum and '-e' option for the exponential light changing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Increase backlight brightness by 5 percent
 
     light -A 5
 
+Decrease backlight brightness by 5 percent in exponential mode (natural way)
+
+    light -e -U 5
+
 Set the minimum cap to 2 in raw value on the sysfs/backlight/acpi_video0 device:
 
     light -Nrs "sysfs/backlight/acpi_video0" 2
@@ -100,6 +104,7 @@ Without any extra options, the command will operate on the device called `sysfs/
 These can be mixed, combined and matched after convenience. 
 
 * `-r` Raw mode, values (printed and interpreted from commandline) will be treated as integers in the controllers native range, instead of in percent.
+* `-e` Exponential mode, values (printed and interpreted from commandline) will be treated as double percentage between 0.0 - 100.0 in the logarithmic scale with base 4.
 * `-v <verbosity>` Specifies the verbosity level. 0 is default and prints nothing. 1 prints only errors, 2 prints only errors and warnings, and 3 prints both errors, warnings and notices.
 * `-s <devicepath>` Specifies which device to work on. List available devices with the -L command. Full path is needed.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Decrease backlight brightness by 5 percent in exponential mode (natural way)
 
     light -e -U 5
 
+Increase backlight brightness by 2 percent in exponential mode and specify exponential base K, it must be more then 1.0 and less then 20.0
+
+    light -e2.8 -U 2
+
 Set the minimum cap to 2 in raw value on the sysfs/backlight/acpi_video0 device:
 
     light -Nrs "sysfs/backlight/acpi_video0" 2

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS   = light
 light_SOURCES  = main.c light.c light.h helpers.c helpers.h impl/sysfs.c impl/sysfs.h impl/util.h impl/util.c impl/razer.h impl/razer.c
 light_CPPFLAGS = -I../include -D_GNU_SOURCE
-light_CFLAGS   = -W -Wall -Wextra -std=gnu99 -Wno-type-limits -Wno-format-truncation -Wno-unused-parameter -fcommon
+light_CFLAGS   = -W -Wall -Wextra -std=gnu99 -Wno-type-limits -Wno-format-truncation -Wno-unused-parameter -fcommon -lm
 
 if CLASSIC
 install-exec-hook:

--- a/src/light.c
+++ b/src/light.c
@@ -185,7 +185,7 @@ static bool _light_percent_to_raw(light_context_t *ctx, double inpercent, uint64
     else
         target_value_d = max_value_d * (light_percent_clamp(inpercent) / 100.0);
     uint64_t target_value = LIGHT_CLAMP((uint64_t)target_value_d, 0, max_value);
-    *outraw = target_value;
+    *outraw = round(target_value);
     
     return true;
 }
@@ -880,7 +880,7 @@ bool light_cmd_add_brightness(light_context_t *ctx)
         return false;
     }
     
-    uint64_t value = 0;
+    uint64_t value = 0, new_value = 0;
     if(!target->get_value(target, &value))
     {
         LIGHT_ERR("failed to read from target");
@@ -909,11 +909,15 @@ bool light_cmd_add_brightness(light_context_t *ctx)
             return false;
         }
         percent += ctx->run_params.float_value;
-        if(!_light_percent_to_raw(ctx, percent, &value))
+        if(!_light_percent_to_raw(ctx, percent, &new_value))
         {
             LIGHT_ERR("failed to convert value from percent to raw for device target");
             return false;
-        }        
+        }
+        if(new_value <= value)
+            value += 1;
+        else
+            value = new_value;
         break;
     }
     
@@ -976,7 +980,7 @@ bool light_cmd_sub_brightness(light_context_t *ctx)
         {
             LIGHT_ERR("failed to convert value from percent to raw for device target");
             return false;
-        }        
+        }
         break;
     }
     

--- a/src/light.c
+++ b/src/light.c
@@ -403,7 +403,7 @@ static bool _light_parse_arguments(light_context_t *ctx, int argc, char** argv)
                 return false;
             }
             
-            percent_value = light_percent_clamp(percent_value);                        
+            percent_value = light_percent_clamp(percent_value);
             need_float_value = true;
         }
     }

--- a/src/light.h
+++ b/src/light.h
@@ -26,6 +26,9 @@ typedef bool (*LFUNCVALGET)(light_device_target_t*, uint64_t*);
 typedef bool (*LFUNCMAXVALGET)(light_device_target_t*, uint64_t*);
 typedef bool (*LFUNCCUSTOMCMD)(light_device_target_t*, char const *);
 
+/* Constant for exponential mode */
+#define LIGHT_EXPONENT 4.0
+
 /* Describes a target within a device (for example a led on a keyboard, or a controller for a backlight) */
 struct _light_device_target_t
 {
@@ -68,6 +71,12 @@ typedef struct _light_context_t light_context_t;
 // A command that can be run (set, get, add, subtract, print help, print version, list devices etc.)
 typedef bool (*LFUNCCOMMAND)(light_context_t *);
 
+typedef enum _light_context_mode {
+    LC_MODE_PERCENTAGE,
+    LC_MODE_RAW,
+    LC_MODE_EXPONENTIAL
+} light_context_mode;
+
 struct _light_context_t
 {
     struct 
@@ -76,7 +85,7 @@ struct _light_context_t
         // Only one of value and raw_value is populated; which one depends on the command
         uint64_t                value; // The input value, in raw mode
         float                   float_value; // The input value as a float
-        bool                    raw_mode; // Whether or not we use raw or percentage mode
+        light_context_mode      mode; // Whether or not we use raw, exponential or percentage mode
         light_device_target_t   *device_target; // The device target to act on
     } run_params;
 

--- a/src/light.h
+++ b/src/light.h
@@ -85,6 +85,7 @@ struct _light_context_t
         // Only one of value and raw_value is populated; which one depends on the command
         uint64_t                value; // The input value, in raw mode
         float                   float_value; // The input value as a float
+        double                  exponent; // Exponent value for the exponential mode
         light_context_mode      mode; // Whether or not we use raw, exponential or percentage mode
         light_device_target_t   *device_target; // The device target to act on
     } run_params;


### PR DESCRIPTION
Selection of raw, percentage or exponential mode now done using enum light_context_mode and field ctx->run_params.mode.
Argument '-e' enables exponential mode which will change brightness in natural way for some displays, using logarithmic scale with base 4.