### PR TITLE
Smooth brightness transitions

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -17,6 +17,18 @@
 
 /* Static helper functions for this file only, prefix with _ */
 
+// Changes brightness smoothly from start value to end value
+static void _fade_value(light_device_target_t *target, uint64_t start_value, uint64_t end_value)
+{
+    int steps = 20;
+    uint64_t step_size = (uint64_t) ( ((float)end_value - (float)start_value) / (float)steps );
+
+    for(int i=1; i<steps-1; i++)
+    {
+      target->set_value(target, start_value + i * step_size);
+      usleep(10000);
+    }
+}
 
 static void _light_add_enumerator_device(light_device_enumerator_t *enumerator, light_device_t *new_device)
 {
@@ -721,13 +733,16 @@ bool light_cmd_set_brightness(light_context_t *ctx)
         return false;
     }
     
-    
     uint64_t mincap = _light_get_min_cap(ctx);
     uint64_t value = ctx->run_params.value;
     if(mincap > value)
     {
         value = mincap;
     }
+
+    uint64_t start_value;
+    target->get_value(target, &start_value);
+    _fade_value(target, start_value, value);
     
     if(!target->set_value(target, value))
     {
@@ -899,6 +914,10 @@ bool light_cmd_add_brightness(light_context_t *ctx)
         value = max_value;
     }
     
+    uint64_t start_value;
+    target->get_value(target, &start_value);
+    _fade_value(target, start_value, value);
+
     if(!target->set_value(target, value))
     {
         LIGHT_ERR("failed to write to target");
@@ -938,6 +957,10 @@ bool light_cmd_sub_brightness(light_context_t *ctx)
     {
         value = mincap;
     }
+
+    uint64_t start_value;
+    target->get_value(target, &start_value);
+    _fade_value(target, start_value, value);
 
     if(!target->set_value(target, value))
     {
@@ -993,6 +1016,10 @@ bool light_cmd_mul_brightness(light_context_t *ctx)
     {
         value = max_value;
     }
+
+    uint64_t start_value;
+    target->get_value(target, &start_value);
+    _fade_value(target, start_value, value);
 
     if(!target->set_value(target, value))
     {

--- a/src/light.h
+++ b/src/light.h
@@ -78,6 +78,7 @@ struct _light_context_t
         float                   float_value; // The input value as a float
         bool                    raw_mode; // Whether or not we use raw or percentage mode
         light_device_target_t   *device_target; // The device target to act on
+        int32_t                 smooth_ms; // Smoothing time in milliseconds
     } run_params;
 
     struct


### PR DESCRIPTION
Allows smooth brightness transitions, as requested in #33. The length of time over which to interpolate can be set with the `-t` command line argument (in milliseconds). The length of each brightness step is currently not configurable (set to 10 milliseconds). By default `-t` is set to zero, so the default behaviour is unchanged.

This is using a simple for-loop with a `usleep` delay. As mentioned in the above issue, this method has problems with race conditions until #72 is dealt with. However, in practice it already seems to work ok on my hardware. The brightness can end up at weird decimal values if changed quickly, but there is no 'jittery' behaviour and brightness always changes smoothly.