### PR TITLE
Only initialize light rc when needed

### DIFF
--- a/src/light.c
+++ b/src/light.c
@@ -70,7 +70,7 @@ static void _light_add_device_target(light_device_t *device, light_device_target
     device->num_targets = new_num_targets;
 }
 
-static bool light_rc_initialize(light_context_t *new_ctx) {
+static bool _light_rc_initialize(light_context_t *new_ctx) {
     // Setup the configuration folder
     // If we are root, use the system-wide configuration folder, otherwise try to find a user-specific folder, or fall back to ~/.config
     uid_t euid = geteuid();
@@ -105,7 +105,7 @@ static bool light_rc_initialize(light_context_t *new_ctx) {
 
 static void _light_get_target_path(light_context_t* ctx, char* output_path, size_t output_size)
 {
-    if (light_rc_initialize(ctx)) {
+    if (_light_rc_initialize(ctx)) {
       snprintf(output_path, output_size, "%s/targets/%s/%s/%s",
                ctx->sys_params.conf_dir,
                ctx->run_params.device_target->device->enumerator->name,
@@ -116,7 +116,7 @@ static void _light_get_target_path(light_context_t* ctx, char* output_path, size
 
 static void _light_get_target_file(light_context_t* ctx, char* output_path, size_t output_size, char const * file)
 {
-    if (light_rc_initialize(ctx)) {
+    if (_light_rc_initialize(ctx)) {
       snprintf(output_path, output_size, "%s/targets/%s/%s/%s/%s",
                ctx->sys_params.conf_dir,
                ctx->run_params.device_target->device->enumerator->name,


### PR DESCRIPTION
This is an attempt to fix #129.

> Even if there is no .config arguments being used, (eg: -O or -I), the .config dir is unconditionally created, and the program unconditionally errors out if that creation fails.
> 
> This means that daemon accounts with $HOME set to something like /dev/null will never be able to run any command, even if they have the correct permissions (ie: in the video group) and are not using any save/restore features.

I don't have a deep understanding of C so I don't know if this is 100% correct, but this seems like a reasonable starting point for a fix.